### PR TITLE
Fix bug when specifying explicit path in loadSamples

### DIFF
--- a/Classes/Ziva.sc
+++ b/Classes/Ziva.sc
@@ -160,8 +160,8 @@ Ziva {
 	/// \returns Dictionary
 	*loadSamples { arg path, server = nil;
 		try {
-			path = path ? Ziva.filenameSymbol.asString.asPathName.parentPath +/+ "../samples";
-			this.samplesDict = this.samplesDict ? Dictionary.new;
+			path = path ?? { Ziva.filenameSymbol.asString.asPathName.parentPath +/+ "../samples" };
+			this.samplesDict = this.samplesDict ?? { Dictionary.new };
 			server = server ? this.server ? Server.default;
 			PathName(path).entries.do { |item, i|
 				// d.add(item.folderName -> this.loadSamplesArray(item.fullPath, server));


### PR DESCRIPTION
Bug with order of operations was preventing use of a custom path in `Ziva.loadSamples("some/path")`.