### PR TITLE
Interop with Bacalao (string and character) pattern parsing

### DIFF
--- a/Classes/symbol.sc
+++ b/Classes/symbol.sc
@@ -8,7 +8,26 @@
 		};
 	}
 
-	<> { | pbind | ^Pchain(this.prSynthOrSample, pbind) }
+	// Interop with Bacalao pattern parsing (https://github.com/totalgee/bacalao/)
+	<> { arg pattern, adverb;
+		var validateMethod = { arg receiver, method;
+			if (receiver.respondsTo(method).not) {
+				Error("Bacalao needs to be installed to use '<>' with a %.% -- use Quarks.install(\"https://github.com/totalgee/bacalao/\")".format(receiver.class, method)).throw;
+			}
+		};
+		pattern = case
+		{ pattern.isKindOf(String) } {
+			validateMethod.(pattern, 'bparse');
+			pattern.bparse(adverb ? \degree, inf);
+		}
+		{ pattern.isKindOf(Symbol) } {
+			pattern = pattern.asString;
+			validateMethod.(pattern, 'cparse');
+			pattern.cparse(adverb ? \degree, inf);
+		}
+		{ pattern };
+		^Pchain(this.prSynthOrSample, pattern);
+	}
 
 	controls { Ziva.controls(this) }
 


### PR DESCRIPTION
- support the '<>' operator after a symbol, with optional "adverbs" after a '.', which specify the key you want to use for the parsed pattern (defaults to 'degree'). Example: \d1 play: [\acid <>.deg "0 [1 2] [3 4]*2 7" slow: 4]
- the default duration of Bacalao-parsed patterns is one cycle, so you may need to stretch them out to longer, using 'stretch' or 'slow' keys, or adjusting Ziva's tempo as needed.
- "string" patterns have a similar syntax to Tidal Cycles patterns.
- 'character' patterns (specified using a Symbol) are sequences where each character is an event, and spaces are Rests). Numbers and letters have significance, and '_' will extend a note. Also, the '|' character can be used to describe multiple bars.
- see Bacalao (https://github.com/totalgee/bacalao/) documentation for more information on the syntax of pattern parsing.