### PR TITLE
Avoid double-monitoring of tracks when FX are used

### DIFF
--- a/Classes/symbol.sc
+++ b/Classes/symbol.sc
@@ -134,11 +134,16 @@
 		// clear unused fx
 		(fxNdef.sources.size - effects.size).do{|i| fxNdef[i + effects.size + 1] = nil};
 
+		// Now that we have an FX Ndef playing,
+		// we don't want to play (monitor) the original any more
+		Ndef(this).stop(fxNdef.fadeTime);
+
 		^fxNdef;
 	}
 
 	set { | ... pairs |
-		Ndef(('\fx_'++this).asSymbol).set(*pairs);
+		var fxNdef = this.prGetFxNdef;
+		fxNdef.set(*pairs);
 	}
 
 	wet { | amt = 0.5 |


### PR DESCRIPTION
- previously, both the main \trk and the \fx_trk were heard, which resulted in increased volume when applying FX (and the main track was heard even when `wet` was 1).